### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 MCP server for creating Pokémon pastes (pokepastes)
 
+<a href="https://glama.ai/mcp/servers/@jpbullalayao/pokemon-paste-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jpbullalayao/pokemon-paste-mcp/badge" alt="Pokemon Paste Server MCP server" />
+</a>
+
 ## Installation
 
 ### From npm (Recommended)


### PR DESCRIPTION
This PR adds a badge for the [Pokemon Paste MCP Server](https://glama.ai/mcp/servers/@jpbullalayao/pokemon-paste-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@jpbullalayao/pokemon-paste-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jpbullalayao/pokemon-paste-mcp/badge" alt="Pokemon Paste Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.